### PR TITLE
Call Application.Run passing ApplicationContext, not MainForm

### DIFF
--- a/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/vbruntime/Microsoft.VisualBasic/Microsoft.VisualBasic.ApplicationServices/WindowsFormsApplicationBase.vb
@@ -193,7 +193,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 End If
             End If
 
-            Application.Run(MainForm)
+            Application.Run(ApplicationContext)
         End Sub
 
         <EditorBrowsable(EditorBrowsableState.Advanced)> _


### PR DESCRIPTION
Passing MainForm prevents WindowsFormsApplicationBase.ShutdownStyle from having any effect. It will always shut down when MainForm closes. This fixes that by passing the WindowsFormsApplicationContext, which handles OnMainFormClosed in a way that supports ShutdownStyle.